### PR TITLE
Generate image with cppcheck 2.7 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.1-alpine AS base
 
-ENV CPPCHECK_VERSION=1.90
+ENV CPPCHECK_VERSION=2.7
 
 WORKDIR /tmp/cppcheck
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Here is the versions matrix of the image:
 
 |                                    TAG                                        |                       CPPCHECK VERSION                       |                        BASE IMAGE                      |
 |:-----------------------------------------------------------------------------:|:------------------------------------------------------------:|:------------------------------------------------------:|
-| [latest](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/1.90) | [1.90](https://github.com/danmar/cppcheck/releases/tag/1.90) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
+| [latest](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.7) | [2.7](https://github.com/danmar/cppcheck/releases/tag/2.7) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
+| [2.7](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.7) | [2.7](https://github.com/danmar/cppcheck/releases/tag/2.7) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
 |  [1.90](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/1.90)  | [1.90](https://github.com/danmar/cppcheck/releases/tag/1.90) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
 
 ### How to contribute


### PR DESCRIPTION
Permet d'avoir l'image cppcheck avec la version de cppcheck sur depuis le tag 2.7

J'ai juste lancé le build de l'image et lancé un run pour avoir l'aide et la version de cppcheck.
Ne connaissant pas l'intégration continue, je n'ai pas mis à jour le README avec la version 2.7 de disponible et si le tag latest va évoluer.
