### PR TITLE
Mise à jour de la version de Cppcheck à 2.17.1 dans le Dockerfile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: '*'
   pull_request:
     branches: '*'
+  workflow_dispatch:
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.1-alpine AS base
 
-ENV CPPCHECK_VERSION=2.7
+ENV CPPCHECK_VERSION=2.17.1
 
 WORKDIR /tmp/cppcheck
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Here is the versions matrix of the image:
 
 |                                    TAG                                        |                       CPPCHECK VERSION                       |                        BASE IMAGE                      |
 |:-----------------------------------------------------------------------------:|:------------------------------------------------------------:|:------------------------------------------------------:|
-| [latest](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.7) | [2.7](https://github.com/danmar/cppcheck/releases/tag/2.7) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
+| [latest](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.17.1) | [2.17.1](https://github.com/danmar/cppcheck/releases/tag/2.17.1) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
+| [2.17.1](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.17.1) | [2.17.1](https://github.com/danmar/cppcheck/releases/tag/2.17.1) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
 | [2.7](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/2.7) | [2.7](https://github.com/danmar/cppcheck/releases/tag/2.7) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
 |  [1.90](https://github.com/cnescatlab/cppcheck/pkgs/container/cppcheck/1.90)  | [1.90](https://github.com/danmar/cppcheck/releases/tag/1.90) | [python:3.8.1-alpine](https://hub.docker.com/_/python) |
 


### PR DESCRIPTION
## Proposed changes

Mets à jour la version de Cppcheck avec la dernière version actuelle.
Cela corrige le ticket #2 
On a modifié le pipeline pour pouvoir le lancer directement depuis l'IHM